### PR TITLE
Optionally batch batch synchronisation

### DIFF
--- a/applications/amc-counter/src/lib.rs
+++ b/applications/amc-counter/src/lib.rs
@@ -308,6 +308,7 @@ mod tests {
         let model_opts = ModelOpts {
             servers: 2,
             sync_method: SyncMethod::Changes,
+            batch_synchronisation: false,
             restarts: false,
             in_sync_check: false,
             save_load_check: false,
@@ -342,6 +343,7 @@ mod tests {
         let model_opts = ModelOpts {
             servers: 2,
             sync_method: SyncMethod::Changes,
+            batch_synchronisation: false,
             restarts: false,
             in_sync_check: false,
             save_load_check: false,
@@ -376,6 +378,7 @@ mod tests {
         let model_opts = ModelOpts {
             servers: 2,
             sync_method: SyncMethod::Changes,
+            batch_synchronisation: false,
             restarts: false,
             in_sync_check: false,
             save_load_check: false,
@@ -410,6 +413,7 @@ mod tests {
         let model_opts = ModelOpts {
             servers: 2,
             sync_method: SyncMethod::Changes,
+            batch_synchronisation: false,
             restarts: false,
             in_sync_check: false,
             save_load_check: false,

--- a/applications/amc-counter/src/lib.rs
+++ b/applications/amc-counter/src/lib.rs
@@ -326,15 +326,13 @@ mod tests {
             model_opts,
             counter_opts,
             expect![[r#"
-                Done states=1193, unique=883, max_depth=7
-                Discovered "correct value" counterexample Path[6]:
+                Done states=222, unique=179, max_depth=5
+                Discovered "correct value" counterexample Path[4]:
                 - Deliver { src: Id(2), dst: Id(0), msg: ClientToServer(Input(Increment)) }
                 - Deliver { src: Id(4), dst: Id(1), msg: ClientToServer(Input(Increment)) }
-                - Timeout(Id(0), Server(Synchronise))
                 - Deliver { src: Id(0), dst: Id(1), msg: ServerToServer(SyncChangeRaw { missing_changes_bytes: ["hW9Kg9HytnIBLQAIAAAAAAAAAAABAQAAAAYVCTQBQgJWAlcBcAJ/B2NvdW50ZXIBfwF/FAF/AA"] }) }
-                - Timeout(Id(1), Server(Synchronise))
                 - Deliver { src: Id(1), dst: Id(0), msg: ServerToServer(SyncChangeRaw { missing_changes_bytes: ["hW9Kg37mM9cBLQAIAAAAAAAAAAEBAQAAAAYVCTQBQgJWAlcBcAJ/B2NvdW50ZXIBfwF/FAF/AA"] }) }
-                To explore this path try re-running with `explore 1525806181380480722/5180418002550223678/5944152108436530398/6844139681497215916/14420335236416177080/8613034781207194886/10065992036751478607`"#]],
+                To explore this path try re-running with `explore 8399851022870237940/16806491862266398352/5438897868953376969/16701553720798388135/13315330198982492364`"#]],
         );
     }
 
@@ -361,15 +359,13 @@ mod tests {
             model_opts,
             counter_opts,
             expect![[r#"
-                Done states=1193, unique=883, max_depth=7
-                Discovered "correct value" counterexample Path[6]:
+                Done states=222, unique=179, max_depth=5
+                Discovered "correct value" counterexample Path[4]:
                 - Deliver { src: Id(2), dst: Id(0), msg: ClientToServer(Input(Increment)) }
                 - Deliver { src: Id(4), dst: Id(1), msg: ClientToServer(Input(Increment)) }
-                - Timeout(Id(0), Server(Synchronise))
                 - Deliver { src: Id(0), dst: Id(1), msg: ServerToServer(SyncChangeRaw { missing_changes_bytes: ["hW9Kg8uC6w0BOQAIAAAAAAAAAAABAQAAAAgVCTQBQgNWA1cCcANxAnMCAgdjb3VudGVyAn4BBX4YFAABfgABfwB/AQ"] }) }
-                - Timeout(Id(1), Server(Synchronise))
                 - Deliver { src: Id(1), dst: Id(0), msg: ServerToServer(SyncChangeRaw { missing_changes_bytes: ["hW9Kg5SFxa4BOQAIAAAAAAAAAAEBAQAAAAgVCTQBQgNWA1cCcANxAnMCAgdjb3VudGVyAn4BBX4YFAABfgABfwB/AQ"] }) }
-                To explore this path try re-running with `explore 1525806181380480722/17097366349952166707/8593760643917371053/10515671521338280547/2964746799589016998/3743303551252853264/13106660646034931466`"#]],
+                To explore this path try re-running with `explore 8399851022870237940/6286690770233473543/7056331258323820444/9617842048992555650/16723310297820614748`"#]],
         );
     }
 
@@ -396,15 +392,13 @@ mod tests {
             model_opts,
             counter_opts,
             expect![[r#"
-                Done states=1193, unique=883, max_depth=7
-                Discovered "correct value" counterexample Path[6]:
+                Done states=222, unique=179, max_depth=5
+                Discovered "correct value" counterexample Path[4]:
                 - Deliver { src: Id(2), dst: Id(0), msg: ClientToServer(Input(Increment)) }
                 - Deliver { src: Id(4), dst: Id(1), msg: ClientToServer(Input(Increment)) }
-                - Timeout(Id(0), Server(Synchronise))
                 - Deliver { src: Id(0), dst: Id(1), msg: ServerToServer(SyncChangeRaw { missing_changes_bytes: ["hW9Kg/YbISQBXgFSivc63RbdozTgVxdZsTebmtG2LZfGjrMebHARiIr6ywgAAAAAAAAAAAECAAABCAAAAAAAAAPnCBUJNAFCAlYCVwFwAnECcwJ/B2NvdW50ZXIBfwF/FAF/AX8BfwE"] }) }
-                - Timeout(Id(1), Server(Synchronise))
                 - Deliver { src: Id(1), dst: Id(0), msg: ServerToServer(SyncChangeRaw { missing_changes_bytes: ["hW9Kg7tkl20BXgFSivc63RbdozTgVxdZsTebmtG2LZfGjrMebHARiIr6ywgAAAAAAAAAAQECAAABCAAAAAAAAAPnCBUJNAFCAlYCVwFwAnECcwJ/B2NvdW50ZXIBfwF/FAF/AX8BfwE"] }) }
-                To explore this path try re-running with `explore 11282747607017160468/5938715736771673525/8215538973129948655/8182588904830695981/13837347306307031713/3101484924508244605/5391279161082374327`"#]],
+                To explore this path try re-running with `explore 13057938546621334551/15046840202489597371/6604804354041139761/5847114616358703178/9862545585125496178`"#]],
         );
     }
 
@@ -431,7 +425,7 @@ mod tests {
             model_opts,
             counter_opts,
             expect![[r#"
-                Done states=7477, unique=4649, max_depth=13
+                Done states=1241, unique=897, max_depth=9
             "#]],
         );
     }

--- a/applications/amc-moves/src/lib.rs
+++ b/applications/amc-moves/src/lib.rs
@@ -270,15 +270,13 @@ mod tests {
             model_opts,
             moves_opts,
             expect![[r#"
-                Done states=502, unique=289, max_depth=7
-                Discovered "no duplicates when in sync" counterexample Path[6]:
+                Done states=147, unique=89, max_depth=5
+                Discovered "no duplicates when in sync" counterexample Path[4]:
                 - Deliver { src: Id(2), dst: Id(0), msg: ClientToServer(Input(Move(0, 0))) }
                 - Deliver { src: Id(4), dst: Id(1), msg: ClientToServer(Input(Move(0, 0))) }
-                - Timeout(Id(0), Server(Synchronise))
                 - Deliver { src: Id(0), dst: Id(1), msg: ServerToServer(SyncChangeRaw { missing_changes_bytes: ["hW9Kg4uoy0wBagEZ2/yCVWqEhxxbv8U9m/PGQRtWd/xxKYnwuCsD89CoxwgAAAAAAAAAAAEDAAABCAAAAAAAAAPnCwECAgIRBBMDNAJCA1YDVwFwA3ECcwICAQIBfwEAAX4CfgEBfgMBfgAWYX4BAH8BfwI"] }) }
-                - Timeout(Id(1), Server(Synchronise))
                 - Deliver { src: Id(1), dst: Id(0), msg: ServerToServer(SyncChangeRaw { missing_changes_bytes: ["hW9Kg+/vwrgBagEZ2/yCVWqEhxxbv8U9m/PGQRtWd/xxKYnwuCsD89CoxwgAAAAAAAAAAQEDAAABCAAAAAAAAAPnCwECAgIRBBMDNAJCA1YDVwFwA3ECcwICAQIBfwEAAX4CfgEBfgMBfgAWYX4BAH8BfwI"] }) }
-                To explore this path try re-running with `explore 989895131523661519/12126579709578502203/4236396483328634040/7267937768031212210/2324762786091901137/1688099541537975566/14767950816351140781`"#]],
+                To explore this path try re-running with `explore 4596863851397185902/2059890198849569732/13637464084275399675/4742061144080449335/13795561724444561862`"#]],
         );
     }
 
@@ -300,16 +298,17 @@ mod tests {
             model_opts,
             moves_opts,
             expect![[r#"
-                Done states=5403, unique=2013, max_depth=8
-                Discovered "no duplicates when in sync" counterexample Path[7]:
+                Done states=1211, unique=649, max_depth=9
+                Discovered "no duplicates when in sync" counterexample Path[8]:
                 - Deliver { src: Id(2), dst: Id(0), msg: ClientToServer(Input(Move(0, 0))) }
-                - Deliver { src: Id(4), dst: Id(1), msg: ClientToServer(Input(Move(0, 0))) }
-                - Timeout(Id(0), Server(Synchronise))
                 - Deliver { src: Id(0), dst: Id(1), msg: ServerToServer(SyncMessageRaw { message_bytes: "QgGLqMtMsZ0HkCT1v4Lnu5/A93T+avmorCMyhnXoLhztowABAAYCCgcCvF8A" }) }
+                - Deliver { src: Id(1), dst: Id(0), msg: ServerToServer(SyncMessageRaw { message_bytes: "QgEZ2/yCVWqEhxxbv8U9m/PGQRtWd/xxKYnwuCsD89CoxwGLqMtMsZ0HkCT1v4Lnu5/A93T+avmorCMyhnXoLhztowEABQEKByDeAA" }) }
+                - Deliver { src: Id(4), dst: Id(1), msg: ClientToServer(Input(Move(0, 0))) }
+                - Deliver { src: Id(0), dst: Id(1), msg: ServerToServer(SyncMessageRaw { message_bytes: "QgGLqMtMsZ0HkCT1v4Lnu5/A93T+avmorCMyhnXoLhztowABARnb/IJVaoSHHFu/xT2b88ZBG1Z3/HEpifC4KwPz0KjHBQEKB4I9AXSFb0qDi6jLTAFqARnb/IJVaoSHHFu/xT2b88ZBG1Z3/HEpifC4KwPz0KjHCAAAAAAAAAAAAQMAAAEIAAAAAAAAA+cLAQICAhEEEwM0AkIDVgNXAXADcQJzAgIBAgF/AQABfgJ+AQF+AwF+ABZhfgEAfwF/Ag" }) }
                 - Deliver { src: Id(1), dst: Id(0), msg: ServerToServer(SyncMessageRaw { message_bytes: "QgHv78K4b3Sc/TrrMvTnIAggBLNU8+QVc5pKLTSFxsDD7QGLqMtMsZ0HkCT1v4Lnu5/A93T+avmorCMyhnXoLhztowEABgIKB8CsVgF0hW9Kg+/vwrgBagEZ2/yCVWqEhxxbv8U9m/PGQRtWd/xxKYnwuCsD89CoxwgAAAAAAAAAAQEDAAABCAAAAAAAAAPnCwECAgIRBBMDNAJCA1YDVwFwA3ECcwICAQIBfwEAAX4CfgEBfgMBfgAWYX4BAH8BfwI" }) }
-                - Deliver { src: Id(0), dst: Id(1), msg: ServerToServer(SyncMessageRaw { message_bytes: "QgKLqMtMsZ0HkCT1v4Lnu5/A93T+avmorCMyhnXoLhzto+/vwrhvdJz9Ousy9OcgCCAEs1Tz5BVzmkotNIXGwMPtAAEB7+/CuG90nP066zL05yAIIASzVPPkFXOaSi00hcbAw+0FAQoHgj0BdIVvSoOLqMtMAWoBGdv8glVqhIccW7/FPZvzxkEbVnf8cSmJ8LgrA/PQqMcIAAAAAAAAAAABAwAAAQgAAAAAAAAD5wsBAgICEQQTAzQCQgNWA1cBcANxAnMCAgECAX8BAAF+An4BAX4DAX4AFmF+AQB/AX8C" }) }
-                - Deliver { src: Id(1), dst: Id(0), msg: ServerToServer(SyncMessageRaw { message_bytes: "QgKLqMtMsZ0HkCT1v4Lnu5/A93T+avmorCMyhnXoLhzto+/vwrhvdJz9Ousy9OcgCCAEs1Tz5BVzmkotNIXGwMPtAAECi6jLTLGdB5Ak9b+C57ufwPd0/mr5qKwjMoZ16C4c7aPv78K4b3Sc/TrrMvTnIAggBLNU8+QVc5pKLTSFxsDD7QAA" }) }
-                To explore this path try re-running with `explore 989895131523661519/12126579709578502203/4236396483328634040/9869795524893107760/13250961904440122108/5028899663474348700/194727513515203086/68795656804177286`"#]],
+                - Deliver { src: Id(0), dst: Id(1), msg: ServerToServer(SyncMessageRaw { message_bytes: "QgKLqMtMsZ0HkCT1v4Lnu5/A93T+avmorCMyhnXoLhzto+/vwrhvdJz9Ousy9OcgCCAEs1Tz5BVzmkotNIXGwMPtAAEB7+/CuG90nP066zL05yAIIASzVPPkFXOaSi00hcbAw+0FAQoHgj0A" }) }
+                - Deliver { src: Id(1), dst: Id(0), msg: ServerToServer(SyncMessageRaw { message_bytes: "QgKLqMtMsZ0HkCT1v4Lnu5/A93T+avmorCMyhnXoLhzto+/vwrhvdJz9Ousy9OcgCCAEs1Tz5BVzmkotNIXGwMPtAAEBi6jLTLGdB5Ak9b+C57ufwPd0/mr5qKwjMoZ16C4c7aMFAQoHgMQA" }) }
+                To explore this path try re-running with `explore 4596863851397185902/221331385123046224/15499083154062355532/8728495104524905156/8859108831131884740/12085236052126249328/8782270388884776451/9630948498218840186/6468371964391684142`"#]],
         );
     }
 }

--- a/applications/amc-moves/src/lib.rs
+++ b/applications/amc-moves/src/lib.rs
@@ -257,6 +257,7 @@ mod tests {
         let model_opts = ModelOpts {
             servers: 2,
             sync_method: SyncMethod::Changes,
+            batch_synchronisation: false,
             restarts: false,
             in_sync_check: false,
             save_load_check: false,
@@ -286,6 +287,7 @@ mod tests {
         let model_opts = ModelOpts {
             servers: 2,
             sync_method: SyncMethod::Messages,
+            batch_synchronisation: false,
             restarts: false,
             in_sync_check: false,
             save_load_check: false,

--- a/applications/amc-todo/src/lib.rs
+++ b/applications/amc-todo/src/lib.rs
@@ -216,15 +216,13 @@ mod tests {
             model_opts,
             todo_opts,
             expect![[r#"
-                Done states=1010, unique=651, max_depth=7
-                Discovered "all apps have the right number of tasks" counterexample Path[6]:
+                Done states=203, unique=162, max_depth=5
+                Discovered "all apps have the right number of tasks" counterexample Path[4]:
                 - Deliver { src: Id(2), dst: Id(0), msg: ClientToServer(Input(CreateTodo("a"))) }
                 - Deliver { src: Id(4), dst: Id(1), msg: ClientToServer(Input(CreateTodo("a"))) }
-                - Timeout(Id(0), Server(Synchronise))
                 - Deliver { src: Id(0), dst: Id(1), msg: ServerToServer(SyncChangeRaw { missing_changes_bytes: ["hW9Kg2FFLKgBTwAIAAAAAAAAAAABAQAAAAgBBAIGFRg0AUIEVgVXAXACAAEDAAABfwECAnwFdG9kb3MBMQljb21wbGV0ZWQEdGV4dAQCAAIBAgB+ARZhBAA"] }) }
-                - Timeout(Id(1), Server(Synchronise))
                 - Deliver { src: Id(1), dst: Id(0), msg: ServerToServer(SyncChangeRaw { missing_changes_bytes: ["hW9Kg7dZRG8BTwAIAAAAAAAAAAEBAQAAAAgBBAIGFRg0AUIEVgVXAXACAAEDAAABfwECAnwFdG9kb3MBMQljb21wbGV0ZWQEdGV4dAQCAAIBAgB+ARZhBAA"] }) }
-                To explore this path try re-running with `explore 15482871843547519777/8203200380951402305/8829712127819938698/9203449192000354338/1513831609101728924/10211774821601995043/3348636454154444996`"#]],
+                To explore this path try re-running with `explore 3618709252656414281/3848895781740508824/3030994841380107975/8235390891822971838/6445604413388662187`"#]],
         );
     }
 
@@ -251,15 +249,13 @@ mod tests {
             model_opts,
             todo_opts,
             expect![[r#"
-                Done states=1311, unique=856, max_depth=7
-                Discovered "all apps have the right number of tasks" counterexample Path[6]:
+                Done states=227, unique=190, max_depth=5
+                Discovered "all apps have the right number of tasks" counterexample Path[4]:
                 - Deliver { src: Id(2), dst: Id(0), msg: ClientToServer(Input(CreateTodo("a"))) }
                 - Deliver { src: Id(4), dst: Id(1), msg: ClientToServer(Input(CreateTodo("a"))) }
-                - Timeout(Id(0), Server(Synchronise))
                 - Deliver { src: Id(0), dst: Id(1), msg: ServerToServer(SyncChangeRaw { missing_changes_bytes: ["hW9Kgwgf+QYBWAAIAAAAAAAAAAABAQAAAAgBBAIGFSE0AUIEVgVXAXACAAEDAAABfwECAnwFdG9kb3MKMzQ0MjI0MTQwNwljb21wbGV0ZWQEdGV4dAQCAAIBAgB+ARZhBAA"] }) }
-                - Timeout(Id(1), Server(Synchronise))
                 - Deliver { src: Id(1), dst: Id(0), msg: ServerToServer(SyncChangeRaw { missing_changes_bytes: ["hW9Kg7WbvTIBWAAIAAAAAAAAAAEBAQAAAAgBBAIGFSE0AUIEVgVXAXACAAEDAAABfwECAnwFdG9kb3MKMzU0MzE0NDU0NQljb21wbGV0ZWQEdGV4dAQCAAIBAgB+ARZhBAA"] }) }
-                To explore this path try re-running with `explore 15482871843547519777/18165317894337760192/694225343320960706/7251433598226590557/3823086620333083307/10110955772386490526/18101974323185263970`"#]],
+                To explore this path try re-running with `explore 3618709252656414281/13152949298909582684/18321986597509055663/17700926072447250057/1499795684066723353`"#]],
         );
     }
 
@@ -286,15 +282,13 @@ mod tests {
             model_opts,
             todo_opts,
             expect![[r#"
-                Done states=1010, unique=651, max_depth=7
-                Discovered "all apps have the right number of tasks" counterexample Path[6]:
+                Done states=203, unique=162, max_depth=5
+                Discovered "all apps have the right number of tasks" counterexample Path[4]:
                 - Deliver { src: Id(2), dst: Id(0), msg: ClientToServer(Input(CreateTodo("a"))) }
                 - Deliver { src: Id(4), dst: Id(1), msg: ClientToServer(Input(CreateTodo("a"))) }
-                - Timeout(Id(0), Server(Synchronise))
                 - Deliver { src: Id(0), dst: Id(1), msg: ServerToServer(SyncChangeRaw { missing_changes_bytes: ["hW9KgxyNDm8BbwHG41V/TSmS0zF9OlKXsY+AGk2OJT4ZQc8yCtzbYlW+IQgAAAAAAAAAAAECAAABCAAAAAAAAAPnCAEEAgQVEjQBQgRWBFcBcAJ/AQIAfwECAn0BMQljb21wbGV0ZWQEdGV4dAN/AAIBfQABFmEDAA"] }) }
-                - Timeout(Id(1), Server(Synchronise))
                 - Deliver { src: Id(1), dst: Id(0), msg: ServerToServer(SyncChangeRaw { missing_changes_bytes: ["hW9Kg75sovgBbwHG41V/TSmS0zF9OlKXsY+AGk2OJT4ZQc8yCtzbYlW+IQgAAAAAAAAAAQECAAABCAAAAAAAAAPnCAEEAgQVEjQBQgRWBFcBcAJ/AQIAfwECAn0BMQljb21wbGV0ZWQEdGV4dAN/AAIBfQABFmEDAA"] }) }
-                To explore this path try re-running with `explore 17492868438200066151/2505832214583032789/1929226361012236889/16042632906015736619/15462423237410012875/16262740734369261783/10226122137356237458`"#]],
+                To explore this path try re-running with `explore 7010877734742148362/10654691187990764641/8397507758268191045/3934490380097970375/4484010949238792495`"#]],
         );
     }
 

--- a/applications/amc-todo/src/lib.rs
+++ b/applications/amc-todo/src/lib.rs
@@ -198,6 +198,7 @@ mod tests {
         let model_opts = ModelOpts {
             servers: 2,
             sync_method: SyncMethod::Changes,
+            batch_synchronisation: false,
             restarts: false,
             in_sync_check: false,
             save_load_check: false,
@@ -232,6 +233,7 @@ mod tests {
         let model_opts = ModelOpts {
             servers: 2,
             sync_method: SyncMethod::Changes,
+            batch_synchronisation: false,
             restarts: false,
             in_sync_check: false,
             save_load_check: false,
@@ -266,6 +268,7 @@ mod tests {
         let model_opts = ModelOpts {
             servers: 2,
             sync_method: SyncMethod::Changes,
+            batch_synchronisation: false,
             restarts: false,
             in_sync_check: false,
             save_load_check: false,
@@ -301,6 +304,7 @@ mod tests {
         let model_opts = ModelOpts {
             servers: 2,
             sync_method: SyncMethod::Changes,
+            batch_synchronisation: false,
             restarts: false,
             in_sync_check: false,
             save_load_check: false,

--- a/crates/amc/src/model.rs
+++ b/crates/amc/src/model.rs
@@ -81,6 +81,10 @@ pub struct ModelOpts {
     #[clap(long, global = true, default_value = "changes")]
     pub sync_method: SyncMethod,
 
+    /// Whether to batch synchronisation in all possible ways.
+    #[clap(long, global = true)]
+    pub batch_synchronisation: bool,
+
     /// Whether to perform server restarts.
     #[clap(long, global = true)]
     pub restarts: bool,
@@ -122,6 +126,7 @@ impl ModelOpts {
             model = model.actor(GlobalActor::Server(Server {
                 peers: model_peers(i, self.servers),
                 sync_method: self.sync_method,
+                batch_synchronisation: self.batch_synchronisation,
                 restarts: self.restarts,
                 app: model_builder.application(i, &config),
             }))


### PR DESCRIPTION
Batching synchronisation (using timers) can get very expensive as it adds lots of states.

This adds an option to go with the simpler strategy of syncing after every change.